### PR TITLE
Consider using stub instead of spy

### DIFF
--- a/chai-backbone.coffee
+++ b/chai-backbone.coffee
@@ -77,7 +77,7 @@
     # reset history to clear active routes
     Backbone.history = new Backbone.History
 
-    spy = sinon.spy router, methodName # spy on our expected method call
+    stub = sinon.stub router, methodName # stub on our expected method call
     @assert router._bindRoutes?, 'provided router is not a Backbone.Router'
 
     router._bindRoutes() # inject router routes into our history
@@ -92,20 +92,20 @@
     # fire our route to test
     Backbone.history.loadUrl route
 
-    # set back our history. The spy should have our collected info now
+    # set back our history. The stub should have our collected info now
     Backbone.history = current_history
     # restore the router method
     router[methodName].restore()
 
     # now assert if everything went according to spec
-    @assert spy.calledOnce,
+    @assert stub.calledOnce,
       "expected `#{route}` to route to #{methodName}",
       "expected `#{route}` not to route to #{methodName}"
 
     # verify arguments if they were provided
     if options.arguments?
-      @assert spy.calledWith(options.arguments...),
-        "expected `#{methodName}` to be called with #{inspect options.arguments}, but was called with #{inspect spy.args[0]} instead",
+      @assert stub.calledWith(options.arguments...),
+        "expected `#{methodName}` to be called with #{inspect options.arguments}, but was called with #{inspect stub.args[0]} instead",
         "expected `#{methodName}` not to be called with #{inspect options.arguments}, but was"
 
   chai.Assertion.overwriteProperty 'to', (_super) ->

--- a/chai-backbone.js
+++ b/chai-backbone.js
@@ -44,13 +44,13 @@
       return flag(this, 'routing', true);
     });
     routeTo = function(router, methodName, options) {
-      var consideredRouter, current_history, route, spy, _i, _len, _ref;
+      var consideredRouter, current_history, route, stub, _i, _len, _ref;
       if (options == null) {
         options = {};
       }
       current_history = Backbone.history;
       Backbone.history = new Backbone.History;
-      spy = sinon.spy(router, methodName);
+      stub = sinon.stub(router, methodName);
       this.assert(router._bindRoutes != null, 'provided router is not a Backbone.Router');
       router._bindRoutes();
       if (options.considering != null) {
@@ -67,9 +67,9 @@
       Backbone.history.loadUrl(route);
       Backbone.history = current_history;
       router[methodName].restore();
-      this.assert(spy.calledOnce, "expected `" + route + "` to route to " + methodName, "expected `" + route + "` not to route to " + methodName);
+      this.assert(stub.calledOnce, "expected `" + route + "` to route to " + methodName, "expected `" + route + "` not to route to " + methodName);
       if (options["arguments"] != null) {
-        return this.assert(spy.calledWith.apply(spy, options["arguments"]), "expected `" + methodName + "` to be called with " + (inspect(options["arguments"])) + ", but was called with " + (inspect(spy.args[0])) + " instead", "expected `" + methodName + "` not to be called with " + (inspect(options["arguments"])) + ", but was");
+        return this.assert(stub.calledWith.apply(stub, options["arguments"]), "expected `" + methodName + "` to be called with " + (inspect(options["arguments"])) + ", but was called with " + (inspect(stub.args[0])) + " instead", "expected `" + methodName + "` not to be called with " + (inspect(options["arguments"])) + ", but was");
       }
     };
     chai.Assertion.overwriteProperty('to', function(_super) {


### PR DESCRIPTION
Since routes usually trigger dom changes such as

``` javascript
var Router = Backbone.Router.extend({
  routes: {
    '': 'index'
  },

  index: function() {
    var layout = new Backbone.View();
    $('body').empty().append(layout.render());
  },
  ...
});
```

Using `chai-backbone` route assertions will break the testrunner page by actually rendering the view(s) into the DOM. 

I changed the `sinon.spy` to `sinon.stub` to exclude actual method execution.
