### PR TITLE
Implement callSuper method.

### DIFF
--- a/chai-backbone.coffee
+++ b/chai-backbone.coffee
@@ -137,5 +137,22 @@
 
     flag(this, 'whenActions', definedActions)
 
+  # verify that a method calls through to base class
+  chai.Assertion.addMethod 'callSuper', (methodName) ->
+    object = flag(this, 'object')
+    base = object.constructor.__super__
+    sinon.spy base, methodName
+    value = object[methodName]()
+    try
+      @assert base[methodName].called,
+        "expected `#{methodName}` to have been called on base class",
+        "expected `#{methodName}` not to have been called on base class"
+      @assert base[methodName].returned(value),
+        "expected `#{methodName}` to have returned base class value",
+        "expected `#{methodName}` not to have returned base class value"
+    catch e
+      base[methodName].restore()
+      throw e
+    base[methodName].restore()
 )
 

--- a/test/chai-backbone_spec.coffee
+++ b/test/chai-backbone_spec.coffee
@@ -93,3 +93,34 @@ describe 'Chai-Backbone matchers', ->
        viewInstance.should.call('eventCall').when ->
          viewInstance.$el.trigger('click')
 
+  describe 'callSuper', ->
+
+    PassClass = Backbone.View.extend
+      render: ->
+        return Backbone.View.prototype.render.call this, arguments
+
+    FailCallThroughClass = Backbone.View.extend
+      render: ->
+
+    FailReturnClass = Backbone.View.extend
+      render: ->
+        Backbone.View.prototype.render.call this, arguments
+        return
+
+    it 'asserts a method calls through to the super', ->
+      view = new PassClass
+      view.should.callSuper 'render'
+
+    it 'raises AssertionError if not called through to the super', ->
+      view = new FailCallThroughClass
+      expect(->
+        view.should.callSuper 'render'
+      ).to.throw /been called/
+
+    it 'raises AssertionError if not super return not returned', ->
+      view = new FailReturnClass
+      expect(->
+        view.should.callSuper 'render'
+      ).to.throw /return/
+
+


### PR DESCRIPTION
* implement callSuper for asserting method on parent was called
* spec callSuper asserting call through and return value.

When overriding a method in a class extention, it is sometimes desirable
to retain the behavior of the super by calling through.  In these cases,
we want to test that the method on the super is indeed called and that
the same return value is returned from both.